### PR TITLE
Add --open (-o) option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ hexo.extend.console.register('server', 'Start the server.', {
     {name: '-i, --ip', desc: 'Override the default server IP. Bind to all IP address by default.'},
     {name: '-p, --port', desc: 'Override the default port.'},
     {name: '-s, --static', desc: 'Only serve static files.'},
-    {name: '-l, --log [format]', desc: 'Enable logger. Override the logger format.'}
+    {name: '-l, --log [format]', desc: 'Enable logger. Override the logger format.'},
+    {name: '-o, --open', desc: 'Immediately open the server url in your default web browser.'}
   ]
 }, require('./lib/server'));
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,6 +2,8 @@ var connect = require('connect');
 var http = require('http');
 var chalk = require('chalk');
 var Promise = require('bluebird');
+var format = require('util').format;
+var open = require('open');
 
 function server(args){
   var app = connect();
@@ -24,8 +26,13 @@ function server(args){
   }).then(function(){
     return startServer(http.createServer(app), port, ip);
   }).then(function(server){
-    self.log.info('Hexo is running at ' + chalk.underline('http://%s:%d%s') + '. Press Ctrl+C to stop.', ip, port, root);
+    var addr = format('http://%s:%d%s', ip, port, root);
+    self.log.info('Hexo is running at %s. Press Ctrl+C to stop.', chalk.underline(addr));
     self.emit('server');
+
+    if (args.o || args.open) {
+      open(addr);
+    }
 
     return server;
   }, function(err){

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "connect": "3.x",
     "mime": "^1.2.11",
     "morgan": "^1.5.0",
+    "open": "0.0.5",
     "serve-static": "^1.7.1",
     "utils-merge": "^1.0.0"
   },


### PR DESCRIPTION
With these changes the user can run `hexo server -o` or `hexo server --open` and their system web browser will open to the url the server is running.