### PR TITLE
0.0.0.0 is not addressable, use 127.0.0.0 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Option | Description | Default
 server:
   port: 4000
   log: false
-  ip: 0.0.0.0
+  ip: 127.0.0.1
 ```
 
 - **port**: Server port

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var assign = require('object-assign');
 hexo.config.server = assign({
   port: 4000,
   log: false,
-  ip: '0.0.0.0'
+  ip: '127.0.0.1'
 }, hexo.config.server);
 
 hexo.extend.console.register('server', 'Start the server.', {


### PR DESCRIPTION
### Purpose
In the old version of Chrome (below 42), 0.0.0.0 is non-routable address.  
![screenshot 2015-08-20 15 19 15](https://cloud.githubusercontent.com/assets/5420789/9393958/54511f78-4753-11e5-9360-06b59576dd9f.png)

### Change
With the similar idea from https://github.com/jekyll/jekyll/issues/3048, `127.0.0.1:4000` may be a good replacement and also works well for local implementation.

### Side effect
So the difference between `0.0.0.0` and `127.0.0.1` are shown in [StackExchange](http://serverfault.com/questions/78048/whats-the-difference-between-ip-address-0-0-0-0-and-127-0-0-1)
> When a service is listening on 0.0.0.0 this means the service is listening on all the configured network interfaces, when listening on 127.0.0.1 the service is only bound to the loopback interface (only available on the local machine)
