### PR TITLE
Restrict loading pages to a specific Google OAuth domain

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ hexo.extend.console.register('server', 'Start the server.', {
   ]
 }, require('./lib/server'));
 
+hexo.extend.filter.register('server_middleware', require('./lib/middlewares/oauth'));
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/header'));
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/gzip'));
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/logger'));

--- a/lib/middlewares/oauth.js
+++ b/lib/middlewares/oauth.js
@@ -1,0 +1,113 @@
+'use strict';
+
+var url = require('url');
+var format = require('util').format;
+var cookieParser = require('cookie-parser');
+var session = require('express-session')
+var passport = require('passport');
+var GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
+
+function configPassport(addr, allowedDomain) {
+
+// used to serialize the user for the session
+  passport.serializeUser(function(user, done) {
+    done(null, user.id);
+  });
+
+// used to deserialize the user
+  passport.deserializeUser(function(obj, done) {
+    done(null, obj);
+  });
+
+// =========================================================================
+// GOOGLE ==================================================================
+// =========================================================================
+  passport.use(new GoogleStrategy({
+    clientID      : process.env.GOOGLE_CLIENT_ID,
+    clientSecret  : process.env.GOOGLE_CLIENT_SECRET,
+    callbackURL   : addr + 'auth/google/callback',
+  },
+  function(token, refreshToken, profile, done) {
+    // make the code asynchronous
+    // User.findOne won't fire until we have all our data back from Google
+    process.nextTick(function() {
+
+      if (profile._json.domain === allowedDomain) {
+        return done(null, profile);
+      } else {
+        return done(new Error("Invalid user domain"), null);
+      }
+
+    });
+  }));
+}
+
+
+module.exports = function(app){
+
+  var config = this.config;
+  var root = config.root;
+  var ip = (config.server.ip === '0.0.0.0') ? 'localhost' : config.server.ip;
+
+  var addr = format('http://%s:%d%s', ip, config.server.port, root);
+
+  var allowedDomain = process.env.OAUTH_ALLOWED_DOMAIN;
+  // if the allowed domain isn't set, don't activate this middleware
+  if (allowedDomain == null) {
+    return;
+  }
+
+  configPassport(addr, allowedDomain);
+
+  app.use(cookieParser()); // read cookies (needed for auth)
+  app.use(session({
+      secret: 'hexo secret tbd enhance',
+      resave: false,
+      saveUninitialized: false
+  }));
+  app.use(passport.initialize());
+  app.use(passport.session()); // persistent login sessions
+
+  app.use(function(req, res, next){
+
+    // route for logging out
+    // not really useful, as you will be redirected to /auth/google and immediately logged in again
+    if (req.url === '/logout') {
+      req.logout();
+      res.statusCode = 302;
+      res.setHeader('Location', addr);
+      res.end('Redirecting');
+      return;
+    }
+
+    // =====================================
+    // GOOGLE ROUTES =======================
+    // =====================================
+    // send to google to do the authentication
+    // profile gets us their basic information including their name
+    // email gets their emails
+    if (req.url === '/auth/google') {
+        passport.authenticate('google', {
+            scope : ['profile email']
+        })(req, res, next);
+        return;
+    };
+
+    // the callback after google has authenticated the user
+    if (url.parse(req.url).pathname === '/auth/google/callback') {
+      passport.authenticate('google', {
+        successRedirect : '/',
+        failureRedirect : '/auth/google'
+      })(req, res, next);
+        return;
+    }
+
+    if (req.isAuthenticated()) {
+      return next();
+    }
+
+    res.statusCode = 302;
+    res.setHeader('Location', addr + 'auth/google');
+    res.end('Redirecting');
+  });
+};

--- a/lib/middlewares/oauth.js
+++ b/lib/middlewares/oauth.js
@@ -45,11 +45,7 @@ function configPassport(addr, allowedDomain) {
 
 module.exports = function(app){
 
-  var config = this.config;
-  var root = config.root;
-  var ip = (config.server.ip === '0.0.0.0') ? 'localhost' : config.server.ip;
-
-  var addr = format('http://%s:%d%s', ip, config.server.port, root);
+  var addr = process.env.SITE_ADDR || this.config.server.addr;
 
   var allowedDomain = process.env.OAUTH_ALLOWED_DOMAIN;
   // if the allowed domain isn't set, don't activate this middleware

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ module.exports = function(args){
   var app = connect();
   var config = this.config;
   var ip = args.i || args.ip || config.server.ip || 'localhost';
-  var port = parseInt(args.p || args.port || config.server.port, 10) || 4000;
+  var port = parseInt(args.p || args.port || config.server.port, 10) || process.env.PORT || 4000;
   var root = config.root;
   var self = this;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ module.exports = function(args){
   var app = connect();
   var config = this.config;
   var ip = args.i || args.ip || config.server.ip || 'localhost';
-  var port = parseInt(args.p || args.port || config.server.port || process.env.PORT, 10) || 4000;
+  var port = parseInt(args.p || args.port || process.env.PORT || config.server.port, 10) || 4000;
   var root = config.root;
   var self = this;
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var connect = require('connect');
+var connect = require('express');
 var http = require('http');
 var chalk = require('chalk');
 var Promise = require('bluebird');

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,9 +11,15 @@ var net = require('net');
 module.exports = function(args){
   var app = connect();
   var config = this.config;
-  var ip = args.i || args.ip || config.server.ip || 'localhost';
-  var port = parseInt(args.p || args.port || process.env.PORT || config.server.port, 10) || 4000;
+
   var root = config.root;
+  var ip = args.i || args.ip || config.server.ip || '0.0.0.0';
+  var port = parseInt(args.p || args.port || process.env.PORT || config.server.port, 10) || 4000;
+  var addr = format('http://%s:%d%s', ip, port, config.root);
+  config.server.ip = ip;
+  config.server.port = port;
+  config.server.addr = addr;
+
   var self = this;
 
   return checkPort(ip, port).then(function(){
@@ -27,7 +33,6 @@ module.exports = function(args){
   }).then(function(){
     return startServer(http.createServer(app), port, ip);
   }).then(function(server){
-    var addr = format('http://%s:%d%s', ip, port, root);
     self.log.info('Hexo is running at %s. Press Ctrl+C to stop.', chalk.underline(addr));
     self.emit('server');
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,7 +12,7 @@ module.exports = function(args){
   var app = connect();
   var config = this.config;
   var ip = args.i || args.ip || config.server.ip || 'localhost';
-  var port = parseInt(args.p || args.port || config.server.port, 10) || process.env.PORT || 4000;
+  var port = parseInt(args.p || args.port || config.server.port || process.env.PORT, 10) || 4000;
   var root = config.root;
   var self = this;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Server module of Hexo.",
   "main": "index",
   "scripts": {
@@ -25,11 +25,15 @@
     "bluebird": "^2.7.1",
     "chalk": "^0.5.1",
     "compression": "^1.3.0",
-    "connect": "3.x",
+    "cookie-parser": "^1.4.0",
+    "express": "4.13.3",
+    "express-session": "^1.11.3",
     "mime": "^1.2.11",
     "morgan": "^1.5.0",
     "object-assign": "^2.0.0",
     "opn": "^1.0.1",
+    "passport": "^0.3.0",
+    "passport-google-oauth": "^0.2.0",
     "serve-static": "^1.7.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I don't expect you to actually merge this, but I wanted to call your attention to it. I wanted to use Hexo for a private blog. I realized by extended `hexo-server` and adding oauth, I could get the result I wanted, which is to only allow users of a certain Google Apps domain to view the blog.

Ideally I would have made a wrapper around hexo-server, but I couldn't figure out how to do that, so I had to hack it directly into the code. By default this feature is disabled, but I would recommend not merging it, because its a pretty special case.

Do you have any advice on how I could make this more general purpose, possibly as a wrapper around hexo-server?

Also, I had to switch from connect to express - I'm not happy about that, but there seems to a be an unsolved bug somewhere: https://github.com/jaredhanson/passport-google-oauth/issues/80