### PR TITLE
Serve on all interfaces by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ hexo server
 
 Option | Description | Default
 --- | --- | ---
-`-i`, `--ip` | Override the default server IP. | 0.0.0.0
+`-i`, `--ip` | Override the default server IP. | `::` when IPv6 is available, else `0.0.0.0` (note: in most systems, `::` also binds to `0.0.0.0`)
 `-p`, `--port` | Override the default port. | 4000
 `-s`, `--static` | Only serve static files. | false
 `-l`, `--log [format]` | Enable logger. Override log format. | false

--- a/lib/server.js
+++ b/lib/server.js
@@ -4,14 +4,14 @@ var connect = require('connect');
 var http = require('http');
 var chalk = require('chalk');
 var Promise = require('bluebird');
-var format = require('util').format;
 var open = require('opn');
 var net = require('net');
+var url = require('url');
 
 module.exports = function(args) {
   var app = connect();
   var config = this.config;
-  var ip = args.i || args.ip || config.server.ip || 'localhost';
+  var ip = args.i || args.ip || config.server.ip || undefined;
   var port = parseInt(args.p || args.port || config.server.port || process.env.port, 10) || 4000;
   var root = config.root;
   var self = this;
@@ -27,9 +27,10 @@ module.exports = function(args) {
   }).then(function() {
     return startServer(http.createServer(app), port, ip);
   }).then(function(server) {
-    var addr = formatAddress(ip, port, root);
+    var addr = server.address();
+    var addrString = formatAddress(ip || addr.address, addr.port, root);
 
-    self.log.info('Hexo is running at %s. Press Ctrl+C to stop.', chalk.underline(addr));
+    self.log.info('Hexo is running at %s. Press Ctrl+C to stop.', chalk.underline(addrString));
     self.emit('server');
 
     if (args.o || args.open) {
@@ -83,7 +84,10 @@ function checkPort(ip, port) {
 }
 
 function formatAddress(ip, port, root) {
-  if (ip === '0.0.0.0') ip = 'localhost';
+  var hostname = ip;
+  if (ip === '0.0.0.0' || ip === '::') {
+    hostname = 'localhost';
+  }
 
-  return format('http://%s:%d%s', ip, port, root);
+  return url.format({protocol: 'http', hostname: hostname, port: port, path: root});
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "maintainers": [
     "Abner Chou <hi@abnerchou.me> (http://abnerchou.me)"
-    ],
+  ],
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.0.6",

--- a/test/index.js
+++ b/test/index.js
@@ -241,4 +241,15 @@ describe('server', function() {
       hexo.log.info.restore();
     });
   });
+
+  it('display localhost instead of [::]', function() {
+    var spy = sinon.spy();
+    sinon.stub(hexo.log, 'info', spy);
+
+    return Promise.using(prepareServer({ip: '::'}), function(app) {
+      spy.args[1][1].should.contain('localhost');
+    }).finally(function() {
+      hexo.log.info.restore();
+    });
+  });
 });


### PR DESCRIPTION
This commit changes the default value of the `--ip` option to use
Node's internal resolution. It means that it will try to bind to
the unspecified IPv6 address `::` if available or else fall back to the
unspecified IPv4 address `0.0.0.0`. In most systems, `::` also binds
to `0.0.0.0` which effectively allows to listen on all interfaces.

Closes hexojs/hexo-server#35