### PR TITLE
Fix default server config to listen on both IPv4 and IPv6

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ var assign = require('object-assign');
 hexo.config.server = assign({
   port: 4000,
   log: false,
-  ip: '0.0.0.0',
+  // `undefined` uses Node's default (try `::` with fallback to `0.0.0.0`)
+  ip: undefined,
   compress: false,
   header: true
 }, hexo.config.server);


### PR DESCRIPTION
This commit is a fix following the PR #39. This PR changed the
default behavior of the server to listen on all interfaces (both
IPv4 and IPv6). This commit was missing the update of the default
configuration, causing the server to still listen only to IPv4 by
default. The current commit fixes this error by using `undefined`
(Node's default) for the IP.

As opposed to #39, this PR should be considered as a patch
(for the semver version) because the change of the default was
already documented for the version `0.3.0`.

- See hexojs/hexo-server#35
- See hexojs/hexo-server#39