### PR TITLE
Fix -o option not working

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,7 @@ module.exports = function(args) {
     self.emit('server');
 
     if (args.o || args.open) {
-      open(addr);
+      open(addrString);
     }
 
     return server;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "mime": "^1.3.4",
     "morgan": "^1.6.1",
     "object-assign": "^4.0.1",
-    "opn": "^4.0.0",
+    "opn": "^5.2.0",
     "serve-static": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It fixes a crash when calling hexo server -o see #42 
It would deserve a test, but they are out of my league. 

I tried something with proxyquire, but it did not work:

```
    var proxyserver = proxyquire('../lib/server', {
      'open': function(url){
        calledUrl = url;
      }
    }).bind(hexo);
  
    return Promise.using(prepareServer({open: true}, proxyserver), function(app) {
      calledUrl.should.be.a("string")
    });
```

See the uncovered line where the bug was: https://coveralls.io/builds/15248944/source?filename=lib%2Fserver.js#L36