### PR TITLE
Change HTTP status code for redirect to 302, Moved Temporarily.

### DIFF
--- a/lib/middlewares/redirect.js
+++ b/lib/middlewares/redirect.js
@@ -8,7 +8,7 @@ module.exports = function(app) {
   app.use(function(req, res, next) {
     if (req.method !== 'GET' || req.url !== '/') return next();
 
-    res.statusCode = 301;
+    res.statusCode = 302;
     res.setHeader('Location', root);
     res.end('Redirecting');
   });

--- a/test/index.js
+++ b/test/index.js
@@ -224,7 +224,7 @@ describe('server', function() {
     return Promise.using(prepareServer(), function(app) {
       return request(app).get('/')
         .expect('Location', '/test/')
-        .expect(301, 'Redirecting')
+        .expect(302, 'Redirecting')
         .end();
     }).finally(function() {
       hexo.config.root = '/';


### PR DESCRIPTION
Many browsers cache a 301 redirect (which is categorically a "Moved Permanently" redirect) permanently.

This causes problems in at least two situations:

1) When developing multiple Hexo sites which use different "root" URLs since the `/` path continues to forward to the `/new-root-path`.
2) When developing any other site on the same port as the Hexo server (for example, another application which uses `localhost:4000`), since it again forwards (until the browser's cache is cleared) to the Hexo "root" path.

While it _might_ make sense to use a 301 redirect on a deployed domain, it doesn't seem necessary in a local development environment.