### PR TITLE
seperated url from dot to fix clickability

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -30,7 +30,7 @@ module.exports = function(args) {
     var addr = server.address();
     var addrString = formatAddress(ip || addr.address, addr.port, root);
 
-    self.log.info('Hexo is running at %s. Press Ctrl+C to stop.', chalk.underline(addrString));
+    self.log.info('Hexo is running at %s . Press Ctrl+C to stop.', chalk.underline(addrString));
     self.emit('server');
 
     if (args.o || args.open) {


### PR DESCRIPTION
would fix https://github.com/Microsoft/vscode/issues/54999

VS Code does not properly distinguesh between the url and the sentence ending dot so I added a space there to fix this the easy way. What do you guys think?