### PR TITLE
fix confusing hostname

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -86,6 +86,8 @@ function checkPort(ip, port) {
 function formatAddress(ip, port, root) {
   var hostname = ip;
   if (ip === '0.0.0.0' || ip === '::') {
+    hostname = '';
+  } else if (ip === 'localhost' || ip === '127.0.0.1') {
     hostname = 'localhost';
   }
 


### PR DESCRIPTION
Even if it's on public(like `0.0.0.0` or '::`) hostname is still `localhost` so it may confuses developers.