### PR TITLE
Fix serving of files from extension-less URLs

### DIFF
--- a/lib/middlewares/route.js
+++ b/lib/middlewares/route.js
@@ -18,15 +18,23 @@ module.exports = function(app) {
     const data = route.get(url);
     const extname = pathFn.extname(url);
 
+    // When the URL is `foo.html` but users access `foo`, try `foo.html`.
+    if (!data && !extname) {
+      data = route.get(url + '.html');
+      extname = 'html';
+    }
+
     // When the URL is `foo/index.html` but users access `foo`, redirect to `foo/`.
     if (!data) {
-      if (extname) return next();
-
-      url = encodeURI(url);
-      res.statusCode = 302;
-      res.setHeader('Location', `${root + url}/`);
-      res.end('Redirecting');
-      return;
+      if (route.get(url + '/')) {
+        url = encodeURI(url);
+        res.statusCode = 302;
+        res.setHeader('Location', `${root + url}/`);
+        res.end('Redirecting');
+        return;
+      } else {
+        return next();
+      }
     }
 
     res.setHeader('Content-Type', extname ? mime.lookup(extname) : 'application/octet-stream');


### PR DESCRIPTION
Previously all URLs in the form of `foo` were redirected to `foo/`,  even if `foo/index.html` didn't exist. This broke handling of such requests when `foo.html` exists.

Fixed by checking if the `foo/` URL is a valid one before redirecting  to it.