### PR TITLE
Add proxying support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Option | Description | Default
 `-s`, `--static` | Only serve static files. | false
 `-l`, `--log [format]` | Enable logger. Override log format. | false
 `-o`, `--open` | Immediately open the server url in your default web browser. | false
+`-P`, `--proxy-path` | Proxy the given path(s) | undefined
+`-U`, `--proxy-url` | Proxy target URL | undefined
 
 ## Options
 
@@ -36,6 +38,8 @@ server:
   serveStatic:
     extensions:
     - html
+  proxyPath: undefined
+  proxyUrl: undefined
 ```
 
 - **port**: Server port
@@ -44,6 +48,7 @@ server:
 - **compress**: Enable GZIP compression
 - **header**: Add `X-Powered-By: Hexo` header
 - **serveStatic**: Extra options passed to [serve-static](https://github.com/expressjs/serve-static#options)
+- **proxyPath**, **proxyUrl**: If specified, an [http-proxy-middleware](https://github.com/chimurai/http-proxy-middleware) proxy will be instantiated as `app.use(proxyPath, proxy({target: proxyUrl, changeOrigin: true}))`.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,9 @@ hexo.extend.console.register('server', 'Start the server.', {
     {name: '-p, --port', desc: 'Override the default port.'},
     {name: '-s, --static', desc: 'Only serve static files.'},
     {name: '-l, --log [format]', desc: 'Enable logger. Override log format.'},
-    {name: '-o, --open', desc: 'Immediately open the server url in your default web browser.'}
+    {name: '-o, --open', desc: 'Immediately open the server url in your default web browser.'},
+    {name: '-P, --proxy-path', desc: 'Proxy this path.'},
+    {name: '-U, --proxy-url', desc: 'Proxy the path specified with -P to this URL.'}
   ]
 }, require('./lib/server'));
 
@@ -30,3 +32,4 @@ hexo.extend.filter.register('server_middleware', require('./lib/middlewares/logg
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/route'));
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/static'));
 hexo.extend.filter.register('server_middleware', require('./lib/middlewares/redirect'));
+hexo.extend.filter.register('server_middleware', require('./lib/middlewares/proxy'));

--- a/lib/middlewares/proxy.js
+++ b/lib/middlewares/proxy.js
@@ -1,0 +1,19 @@
+'use strict';
+
+var proxy = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  var config = this.config;
+  var args = this.env.args || {};
+  var proxyPath = args.P || args.proxyPath || config.server.proxyPath || process.env.proxy_path;
+  var proxyUrl = args.U || args.proxyUrl || config.server.proxyUrl || process.env.proxy_url;
+  
+  if (!proxyPath || !proxyUrl) return;
+  
+  // In case of multiple proxy-url options, ignore all but last.
+  if (Array.isArray(proxyUrl)) {
+    proxyUrl = proxyUrl[proxyUrl.length - 1];
+  }
+  
+  app.use (proxyPath, proxy({target: proxyUrl, changeOrigin: true}));
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "chalk": "^1.1.3",
     "compression": "^1.7.3",
     "connect": "^3.6.6",
+    "http-proxy-middleware": "^0.19.0",
     "mime": "^1.6.0",
     "morgan": "^1.9.0",
     "object-assign": "^4.1.1",


### PR DESCRIPTION
This pull request implements two new `hexo-serve` options that allow a user to proxy certain paths to a remote target. Useful for example to test API integrations when the API endpoints are called via relative URLs from the static part of the site.

## Example

Assuming that you have your API deployment running locally on port 3001, the following command will proxy all URLs starting with `/api` to `localhost:3001`.

```bash
hexo serve -P /api -U http:localhost:3001/
```

*Note: The proxied paths **must not already exist** in the static part of the site.*
