### PR TITLE
Use Object.assign instead of object-assign package

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@
 
 'use strict';
 
-var assign = require('object-assign');
-
-hexo.config.server = assign({
+hexo.config.server = Object.assign({
   port: 4000,
   log: false,
   // `undefined` uses Node's default (try `::` with fallback to `0.0.0.0`)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "connect": "^3.6.6",
     "mime": "^1.6.0",
     "morgan": "^1.9.0",
-    "object-assign": "^4.1.1",
     "opn": "^5.3.0",
     "serve-static": "^1.13.2"
   },


### PR DESCRIPTION
Node.js 4 and up can be use `Object.assign()` instead of `object-assign` npm package.
This repository is already set node engine higher than 6.9.0 .
So, it can use `Object.assign()` .