### PR TITLE
test(appveyor): add node 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,8 @@ init:
 environment:
   matrix:
     - nodejs_version: "8"
-    - nodejs_version: "LTS"
-    - nodejs_version: "Stable"
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
LTS and Stable both refer to 10 currently. Specify versions for clarity.

My previous suggestion: https://github.com/hexojs/hexo-server/pull/87#issuecomment-506929351