### PR TITLE
chore: specify files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-test/
-tmp/
-coverage/
-*.log
-.jshintrc
-.travis.yml
-gulpfile.js
-.idea/
-appveyor.yml

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
   "directories": {
     "lib": "./lib"
   },
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "repository": "hexojs/hexo-server",
   "homepage": "http://hexo.io/",
   "keywords": [


### PR DESCRIPTION
```
$ npm publish --dry-run
npm notice 1.3kB package.json               
npm notice 1.3kB index.js                   
npm notice 1.1kB LICENSE                    
npm notice 1.6kB README.md                  
npm notice 192B  lib/middlewares/gzip.js    
npm notice 218B  lib/middlewares/header.js  
npm notice 320B  lib/middlewares/logger.js  
npm notice 368B  lib/middlewares/redirect.js
npm notice 1.0kB lib/middlewares/route.js   
npm notice 188B  lib/middlewares/static.js  
npm notice 2.3kB lib/server.js
```
Note that I'm not an owner of this package, the command is just a dry run to test whether the necessary files will be published.