### PR TITLE
Changing 302 redirects to 301 redirects

### DIFF
--- a/lib/middlewares/redirect.js
+++ b/lib/middlewares/redirect.js
@@ -8,7 +8,7 @@ module.exports = function(app) {
   app.use((req, res, next) => {
     if (req.method !== 'GET' || req.url !== '/') return next();
 
-    res.statusCode = 302;
+    res.statusCode = 301;
     res.setHeader('Location', root);
     res.end('Redirecting');
   });

--- a/lib/middlewares/route.js
+++ b/lib/middlewares/route.js
@@ -23,7 +23,7 @@ module.exports = function(app) {
       if (extname) return next();
 
       url = encodeURI(url);
-      res.statusCode = 302;
+      res.statusCode = 301;
       res.setHeader('Location', `${root + url}/`);
       res.end('Redirecting');
       return;

--- a/test/index.js
+++ b/test/index.js
@@ -136,7 +136,7 @@ describe('server', () => {
 
   it('append trailing slash', () => Promise.using(prepareServer(), app => request(app).get('/foo')
     .expect('Location', '/foo/')
-    .expect(302, 'Redirecting')));
+    .expect(301, 'Redirecting')));
 
   it('don\'t append trailing slash if URL has a extension name', () => Promise.using(prepareServer(), app => request(app).get('/bar.txt')
     .expect(404)));
@@ -149,7 +149,7 @@ describe('server', () => {
 
     return Promise.using(prepareServer(), app => request(app).get('/')
       .expect('Location', '/test/')
-      .expect(302, 'Redirecting')).finally(() => {
+      .expect(301, 'Redirecting')).finally(() => {
       hexo.config.root = '/';
     });
   });


### PR DESCRIPTION
Reason for changing 302 redirects to 301 redirects is for SEO and indexing