### PR TITLE
feat: support page with trailing '.html'

### DIFF
--- a/lib/middlewares/route.js
+++ b/lib/middlewares/route.js
@@ -10,31 +10,57 @@ module.exports = function(app) {
 
   if (args.s || args.static) return;
 
+  const { pretty_urls } = config;
+  const { trailing_index, trailing_html } = pretty_urls ? pretty_urls : {};
+
   app.use(root, (req, res, next) => {
-    const { method } = req;
+    const { method, url: requestUrl } = req;
     if (method !== 'GET' && method !== 'HEAD') return next();
 
-    let url = route.format(decodeURIComponent(req.url));
+    let url = route.format(decodeURIComponent(requestUrl));
     let data = route.get(url);
     let extname = pathFn.extname(url);
 
     if (!data) {
-      if (route.get(url + '/index.html')) {
-        // When the URL is `foo/index.html` but users access `foo`, redirect to `foo/`.
-        url = encodeURI(url);
-        res.statusCode = 302;
-        res.setHeader('Location', `${root + url}/`);
-        res.end('Redirecting');
-        return;
-      } else if (route.get(url + '.html')) {
-        // When the URL is `foo/bar.html` but users access `foo/bar`, proxy to the URL.
+      if (route.get(url + '.html')) {
+        // location `foo/bar.html`; request `foo/bar`; proxy to the location
         extname = '.html';
         data = route.get(url + extname);
         res.setHeader('Content-Type', 'text/html');
         req.url = encodeURI('/' + url + extname);
         data.pipe(res).on('error', next);
         return;
+      } else if (route.get(url + '/index.html')) {
+        // location `foo/index.html`; request `foo`; redirect to `foo/`
+        url = encodeURI(url);
+        res.statusCode = 301;
+        res.setHeader('Location', `${root + url}/`);
+        res.end('Redirecting');
+        return;
+      } else if (route.get(url.replace(/\/index\.html$/i, '') + '.html')) {
+        // location `foo/bar.html`; request `foo/bar/`; redirect to `foo`
+        // request with trailing slash is appended with index.html by route.format()
+        url = encodeURI(url.replace(/\/index\.html$/i, ''));
+        res.statusCode = 301;
+        res.setHeader('Location', root + url);
+        res.end('Redirecting');
+        return;
       } return next();
+    }
+    if (trailing_html === false && !requestUrl.endsWith('/index.html') && requestUrl.endsWith('.html')) {
+      // location `foo/bar.html`; request `foo/bar.html`; redirect to `foo/bar`
+      url = encodeURI(url.replace(/\.html$/i, ''));
+      res.statusCode = 301;
+      res.setHeader('Location', root + url);
+      res.end('Redirecting');
+      return;
+    } else if (trailing_index === false && requestUrl.endsWith('/index.html')) {
+      // location `foo/index.html`; request `foo/index.html`; redirect to `foo/`
+      url = encodeURI(url.replace(/index\.html$/i, ''));
+      res.statusCode = 301;
+      res.setHeader('Location', root + url);
+      res.end('Redirecting');
+      return;
     }
 
     res.setHeader('Content-Type', extname ? mime.getType(extname) : 'application/octet-stream');

--- a/lib/middlewares/route.js
+++ b/lib/middlewares/route.js
@@ -15,18 +15,26 @@ module.exports = function(app) {
     if (method !== 'GET' && method !== 'HEAD') return next();
 
     let url = route.format(decodeURIComponent(req.url));
-    const data = route.get(url);
-    const extname = pathFn.extname(url);
+    let data = route.get(url);
+    let extname = pathFn.extname(url);
 
-    // When the URL is `foo/index.html` but users access `foo`, redirect to `foo/`.
     if (!data) {
-      if (extname) return next();
-
-      url = encodeURI(url);
-      res.statusCode = 302;
-      res.setHeader('Location', `${root + url}/`);
-      res.end('Redirecting');
-      return;
+      if (route.get(url + '/index.html')) {
+        // When the URL is `foo/index.html` but users access `foo`, redirect to `foo/`.
+        url = encodeURI(url);
+        res.statusCode = 302;
+        res.setHeader('Location', `${root + url}/`);
+        res.end('Redirecting');
+        return;
+      } else if (route.get(url + '.html')) {
+        // When the URL is `foo/bar.html` but users access `foo/bar`, proxy to the URL.
+        extname = '.html';
+        data = route.get(url + extname);
+        res.setHeader('Content-Type', 'text/html');
+        req.url = encodeURI('/' + url + extname);
+        data.pipe(res).on('error', next);
+        return;
+      } return next();
     }
 
     res.setHeader('Content-Type', extname ? mime.getType(extname) : 'application/octet-stream');

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-config-hexo": "^4.0.0",
     "hexo": "^4.0.0",
     "hexo-fs": "^3.0.1",
+    "hexo-util": "^2.1.0",
     "mocha": "^8.0.1",
     "nyc": "^15.0.0",
     "sinon": "^9.0.2",

--- a/test/index.js
+++ b/test/index.js
@@ -156,8 +156,14 @@ describe('server', () => {
       .expect('Location', '/bar/baz'));
   });
 
+  it('trailing_html (default) - no redirect', () => {
+    return Promise.using(prepareServer(), app => request(app).get('/bar/baz.html')
+      .expect(200)
+      .expect('Content-Type', 'text/html'));
+  });
+
   // location `bar/baz.html`; request `bar/baz.html`; redirect to `bar/baz`
-  it('redirects to valid path if available - trailing_html', () => {
+  it('trailing_html (false) - redirect when available', () => {
     hexo.config.pretty_urls.trailing_html = false;
 
     return Promise.using(prepareServer(), app => request(app).get('/bar/baz.html')
@@ -166,7 +172,15 @@ describe('server', () => {
   });
 
   // location `foo/index.html`; request `foo/index.html`; redirect to `foo/`
-  it('redirects to valid path if available - trailing_index', () => {
+  it('trailing_index (default) - no redirect', () => {
+
+    return Promise.using(prepareServer(), app => request(app).get('/foo/index.html')
+      .expect(200)
+      .expect('Content-Type', 'text/html'));
+  });
+
+  // location `foo/index.html`; request `foo/index.html`; redirect to `foo/`
+  it('trailing_index (false) - redirect when available', () => {
     hexo.config.pretty_urls.trailing_index = false;
 
     return Promise.using(prepareServer(), app => request(app).get('/foo/index.html')

--- a/test/index.js
+++ b/test/index.js
@@ -28,8 +28,9 @@ describe('server', () => {
 
   // Register fake generator
   hexo.extend.generator.register('test', () => [
-    {path: '', data: 'index'},
-    {path: 'foo/', data: 'foo'},
+    {path: 'index.html', data: 'index'},
+    {path: 'foo/index.html', data: 'foo'},
+    {path: 'bar/baz.html', data: 'baz'},
     {path: 'bar.jpg', data: 'bar'}
   ]);
 
@@ -137,6 +138,12 @@ describe('server', () => {
   it('append trailing slash', () => Promise.using(prepareServer(), app => request(app).get('/foo')
     .expect('Location', '/foo/')
     .expect(302, 'Redirecting')));
+
+  it('proxy to .html if available', () => {
+    return Promise.using(prepareServer(), app => request(app).get('/bar/baz')
+      .expect(200)
+      .expect('Content-Type', 'text/html'));
+  });
 
   it('don\'t append trailing slash if URL has a extension name', () => Promise.using(prepareServer(), app => request(app).get('/bar.txt')
     .expect(404)));

--- a/test/index.js
+++ b/test/index.js
@@ -95,9 +95,7 @@ describe('server', () => {
       .expect(200)
       .then(res => {
         res.headers.should.not.have.property('x-powered-by');
-      })).finally(() => {
-      hexo.config.server.header = true;
-    });
+      }));
   });
 
   it('Content-Type header', () => Promise.using(prepareServer(), app => request(app).get('/bar.jpg')
@@ -110,9 +108,7 @@ describe('server', () => {
     return Promise.using(
       prepareServer(),
       app => request(app).get('/').expect('Content-Encoding', 'gzip')
-    ).finally(() => {
-      hexo.config.server.compress = false;
-    });
+    );
   });
 
   it('Disable compression if options.compress is false', () => Promise.using(prepareServer(), app => request(app).get('/')
@@ -189,9 +185,7 @@ describe('server', () => {
 
     return Promise.using(prepareServer(), app => request(app).get('/')
       .expect('Location', '/test/')
-      .expect(302, 'Redirecting')).finally(() => {
-      hexo.config.root = '/';
-    });
+      .expect(302, 'Redirecting'));
   });
 
   it('display localhost instead of 0.0.0.0', () => {


### PR DESCRIPTION
TL;DR compatibility with [`pretty_urls.trailing_html = false`](https://hexo.io/docs/configuration#URL)

Currently hexo-server supports redirects like,

```
// source is located at source/bar/index.md
foo.com/bar -> foo.com/bar/ => foo.com/bar/index.html
// -> is redirects
// => is transparent proxy
```

But not when source is located at `source/bar.md`, which requires url to be `foo.com/bar.html`. This can be an issue when `pretty_urls.trailing_html` is disabled.

With this PR,

```
foo.com/bar => foo.com/bar.html
```

Existing redirect/proxy still works.
Also tested with custom `root: /root/` and `server.compress`.

---

Edit:

1.
File: `/foo/bar/index.html`
Request: `/foo/bar/`
Respond: No redirect, serves file directly

2.
File: `/foo/bar/index.html`
Request: `/foo/bar`
Respond: Redirect to `/foo/bar/` and serve using example 1.

3.
File: `/foo/bar/index.html`
Request: `/foo/bar/index.html`
Respond: **If** `pretty_urls.pretty_urls.trailing_index === false`, redirect to `/foo/bar/` and serve using example 1; otherwise, no redirect and serves `/foo/bar/index.html`.

4.
File: `/foo/bar.html`
Request: `/foo/bar`
Respond: No redirect, serves file directly

5.
File: `/foo/bar.html`
Request: `/foo/bar/`
Respond: Redirect to `/foo/bar` and serve using example 4.

6.
File: `/foo/bar.html`
Request: `/foo/bar.html`
Respond: **If** `pretty_urls.pretty_urls.trailing_html === false`, redirect to `/foo/bar` and serve using example 4; otherwise, no redirect and serves `/foo/bar.html`.