### PR TITLE
refactor: use the WHATWG URL API instead of `url.format`

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,6 @@ const { underline } = require('picocolors');
 const Promise = require('bluebird');
 const open = require('open');
 const net = require('net');
-const url = require('url');
 
 module.exports = function(args) {
   const app = connect();
@@ -76,5 +75,6 @@ function formatAddress(ip, port, root) {
     hostname = 'localhost';
   }
 
-  return url.format({protocol: 'http', hostname: hostname, port: port, path: root});
+  let path = root.startsWith("/") ? root : `/${root}`;
+  return new URL(`http://${hostname}:${port}${path}`).toString();
 }


### PR DESCRIPTION
`url.format` is deprecated. Use 

> https://nodejs.org/api/url.html#urlformaturlobject

Use `The WHATWG URL API` instead of it.

> https://nodejs.org/api/url.html#the-whatwg-url-api