### PR TITLE
ci: bump `actions/cache` and `actions/setup-node`

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -9,6 +9,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: ['14.x', '16.x', '18.x']
+        exclude:
+          # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/running-variations-of-jobs-in-a-workflow#excluding-matrix-configurations
+          - os: macos-latest
+            node-version: 14.x
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache NPM dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-npm-cache
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache NPM dependencies
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-npm-cache


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

## Description

`actions/cache@v1` will soon be deprecated. The PR bumps the version of a few actions. The PR also excludes the macOS + Node.js 14 matrix (As there is no Node.js 14 arm64 build).

## Additional information

https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/