### PR TITLE
fix: local serving rss feed file got garbled texts for CJK characters

### DIFF
--- a/lib/middlewares/route.js
+++ b/lib/middlewares/route.js
@@ -67,9 +67,9 @@ module.exports = function(app) {
     if (!res.hasHeader('Content-Type')) {
       if (feed && feed.path === url) {
         if (feed.type === 'atom') {
-          res.setHeader('Content-Type', 'application/atom+xml');
+          res.setHeader('Content-Type', 'application/atom+xml; charset=utf-8');
         } else if (feed.type === 'rss') {
-          res.setHeader('Content-Type', 'application/rss+xml');
+          res.setHeader('Content-Type', 'application/rss+xml; charset=utf-8');
         } else {
           res.setHeader('Content-Type', extname ? mime.getType(extname) : 'application/octet-stream');
         }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo!
-->

## check list

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

## Description

Previously, if my rss feed file contains CJK characters, it will contain garbled texts when viewing in Chrome using `hexo s`.

This is because Chrome defaults to a non-UTF-8 encoding when charset is missing, causing CJK characters to display as garbled text. The fix CL adds that.
